### PR TITLE
feat: layout responsive – header y sidebar para mobile

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import { HashRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { AuthProvider } from './contexts/AuthContext';
 import { OrdersProvider } from './contexts/OrdersContext';
@@ -21,7 +21,10 @@ import Audit from './views/Audit';
 
 const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const location = useLocation();
-  
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const handleSidebarClose = useCallback(() => setSidebarOpen(false), []);
+
   const getTitle = () => {
     if (location.pathname.startsWith('/pedidos/')) {
       return 'Detalle del Pedido';
@@ -39,9 +42,16 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 
   return (
     <div className="flex h-screen w-full overflow-hidden bg-background-light dark:bg-background-dark transition-colors duration-200">
-      <Sidebar />
+      <Sidebar
+        isOpen={sidebarOpen}
+        onClose={handleSidebarClose}
+      />
       <main className="flex-1 flex flex-col min-w-0 bg-background-light dark:bg-background-dark">
-        <Header title={getTitle()} />
+        <Header
+          title={getTitle()}
+          onMenuToggle={() => setSidebarOpen(prev => !prev)}
+          sidebarOpen={sidebarOpen}
+        />
         <div className="flex-1 overflow-y-auto p-4 md:p-8 scroll-smooth no-scrollbar">
           {children}
         </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,9 +6,11 @@ import { useClients } from '../contexts/ClientsContext';
 
 interface HeaderProps {
   title: string;
+  onMenuToggle?: () => void;
+  sidebarOpen?: boolean;
 }
 
-const Header: React.FC<HeaderProps> = ({ title }) => {
+const Header: React.FC<HeaderProps> = ({ title, onMenuToggle, sidebarOpen }) => {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
   const { orders } = useOrders();
@@ -60,23 +62,47 @@ const Header: React.FC<HeaderProps> = ({ title }) => {
     setShowResults(false);
   };
 
+  const touchTarget = 'min-w-[44px] min-h-[44px]'; // Accesibilidad: área táctil mínima 44px
+
   return (
-    <header className="flex items-center justify-between border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-[#1a2634] px-8 py-4 sticky top-0 z-10 transition-colors">
-      <div className="flex items-center gap-4">
+    <header className="flex items-center justify-between border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-[#1a2634] px-4 lg:px-8 py-4 sticky top-0 z-10 transition-colors">
+      {/* Mobile: hamburguesa | título centrado | notificaciones */}
+      <div className="flex lg:hidden items-center justify-between w-full gap-3">
+        <button
+          onClick={onMenuToggle}
+          className={`flex items-center justify-center rounded-lg size-11 text-slate-500 active:bg-slate-200 dark:active:bg-slate-700 dark:text-slate-400 transition-colors ${touchTarget}`}
+          aria-label={sidebarOpen ? 'Cerrar menú' : 'Abrir menú'}
+        >
+          <span className="material-symbols-outlined">{sidebarOpen ? 'close' : 'menu'}</span>
+        </button>
+        <h2 className="flex-1 text-center text-slate-900 dark:text-white text-lg font-bold leading-tight tracking-tight truncate">
+          {title}
+        </h2>
+        <button
+          className={`flex items-center justify-center rounded-lg size-11 text-slate-500 active:bg-slate-200 dark:active:bg-slate-700 dark:text-slate-400 transition-colors relative ${touchTarget}`}
+          aria-label="Notificaciones"
+        >
+          <span className="material-symbols-outlined">notifications</span>
+          <span className="absolute top-3 right-3 size-2 bg-red-500 rounded-full border-2 border-white dark:border-[#1a2634]"></span>
+        </button>
+      </div>
+
+      {/* Desktop: título | búsqueda | 4 botones */}
+      <div className="hidden lg:flex items-center gap-4 flex-1">
         <h2 className="text-slate-900 dark:text-white text-xl font-bold leading-tight tracking-tight">
           {title}
         </h2>
       </div>
-      
-      <div className="flex items-center gap-6">
-        <div className="hidden md:flex flex-col min-w-64 h-10 relative">
+
+      <div className="hidden lg:flex items-center gap-6">
+        <div className="flex flex-col min-w-64 h-10 relative">
           <div className="flex w-full flex-1 items-stretch rounded-lg bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition-all">
             <div className="text-slate-400 flex items-center justify-center pl-3">
               <span className="material-symbols-outlined" style={{ fontSize: '20px' }}>search</span>
             </div>
-            <input 
-              className="flex w-full min-w-0 flex-1 bg-transparent border-none text-slate-900 dark:text-white placeholder:text-slate-400 focus:ring-0 text-sm px-3" 
-              placeholder="Buscar pedidos, clientes..." 
+            <input
+              className="flex w-full min-w-0 flex-1 bg-transparent border-none text-slate-900 dark:text-white placeholder:text-slate-400 focus:ring-0 text-sm px-3"
+              placeholder="Buscar pedidos, clientes..."
               value={searchTerm}
               onChange={handleSearch}
               onFocus={() => searchTerm.trim() && setShowResults(true)}
@@ -118,26 +144,34 @@ const Header: React.FC<HeaderProps> = ({ title }) => {
             </div>
           )}
         </div>
-        
+
         <div className="flex items-center gap-3 border-l border-slate-200 dark:border-slate-700 pl-6">
-          <button className="flex items-center justify-center rounded-lg size-10 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 dark:text-slate-400 transition-colors relative">
+          <button
+            className={`flex items-center justify-center rounded-lg size-11 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 dark:text-slate-400 transition-colors relative ${touchTarget}`}
+            aria-label="Notificaciones"
+          >
             <span className="material-symbols-outlined">notifications</span>
             <span className="absolute top-2.5 right-2.5 size-2 bg-red-500 rounded-full border-2 border-white dark:border-[#1a2634]"></span>
           </button>
-          <button 
+          <button
             onClick={() => document.documentElement.classList.toggle('dark')}
-            className="flex items-center justify-center rounded-lg size-10 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 dark:text-slate-400 transition-colors"
+            className={`flex items-center justify-center rounded-lg size-11 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 dark:text-slate-400 transition-colors ${touchTarget}`}
+            aria-label="Modo oscuro"
           >
             <span className="material-symbols-outlined">dark_mode</span>
           </button>
-          <button className="flex items-center justify-center rounded-lg size-10 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 dark:text-slate-400 transition-colors">
+          <button
+            className={`flex items-center justify-center rounded-lg size-11 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 dark:text-slate-400 transition-colors ${touchTarget}`}
+            aria-label="Configuración"
+          >
             <span className="material-symbols-outlined">settings</span>
           </button>
           {user && (
             <button
               onClick={handleLogout}
-              className="flex items-center justify-center rounded-lg size-10 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 dark:text-slate-400 transition-colors"
+              className={`flex items-center justify-center rounded-lg size-11 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 dark:text-slate-400 transition-colors ${touchTarget}`}
               title="Cerrar sesión"
+              aria-label="Cerrar sesión"
             >
               <span className="material-symbols-outlined">logout</span>
             </button>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,10 +1,31 @@
-
-import React from 'react';
-import { NavLink } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { NavLink, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 
-const Sidebar: React.FC = () => {
-  const { user } = useAuth();
+interface SidebarProps {
+  isOpen?: boolean;
+  onClose?: () => void;
+}
+
+const Sidebar: React.FC<SidebarProps> = ({ isOpen = false, onClose }) => {
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+  const touchTarget = 'min-w-[44px] min-h-[44px]';
+
+  useEffect(() => {
+    if (isOpen && window.innerWidth < 1024) {
+      document.body.style.overflow = 'hidden';
+      const handleEscape = (e: KeyboardEvent) => e.key === 'Escape' && onClose?.();
+      window.addEventListener('keydown', handleEscape);
+      return () => {
+        document.body.style.overflow = '';
+        window.removeEventListener('keydown', handleEscape);
+      };
+    }
+    document.body.style.overflow = '';
+    return undefined;
+  }, [isOpen, onClose]);
+
   const navItems = [
     { name: 'Panel General', icon: 'dashboard', path: '/' },
     { name: 'Productos', icon: 'inventory_2', path: '/productos' },
@@ -14,58 +35,97 @@ const Sidebar: React.FC = () => {
     { name: 'Auditoría', icon: 'fact_check', path: '/auditoria' },
   ];
 
-  return (
-    <aside className="w-72 hidden md:flex flex-col bg-white dark:bg-[#1a2634] border-r border-slate-200 dark:border-slate-800 h-full flex-shrink-0 transition-all duration-300 z-20">
-      <div className="flex flex-col h-full p-4 justify-between">
-        <div className="flex flex-col gap-6">
-          <div className="flex items-center gap-3 px-2">
-            <div className="bg-primary/10 flex items-center justify-center rounded-lg size-10">
-              <span className="material-symbols-outlined text-primary fill">local_shipping</span>
-            </div>
-            <div className="flex flex-col">
-              <h1 className="text-slate-900 dark:text-white text-base font-bold leading-tight">DistriCladera</h1>
-              <p className="text-slate-500 dark:text-slate-400 text-xs font-medium">Administración</p>
-            </div>
+  const handleLogout = () => {
+    if (window.confirm('¿Estás seguro de que deseas cerrar sesión?')) {
+      logout();
+      navigate('/login');
+      onClose?.();
+    }
+  };
+
+  const handleNavClick = () => onClose?.();
+
+  const sidebarContent = (
+    <div className="flex flex-col h-full p-4 justify-between">
+      <div className="flex flex-col gap-6">
+        <div className="flex items-center gap-3 px-2">
+          <div className="bg-primary/10 flex items-center justify-center rounded-lg size-10">
+            <span className="material-symbols-outlined text-primary fill">local_shipping</span>
           </div>
-          
-          <nav className="flex flex-col gap-2">
-            {navItems.map((item) => (
-              <NavLink
-                key={item.name}
-                to={item.path}
-                className={({ isActive }) =>
-                  `flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all group ${
-                    isActive
-                      ? 'bg-primary text-white shadow-md shadow-primary/20'
-                      : 'text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800'
-                  }`
-                }
-              >
-                {/* Fixed the isActive scope error by utilizing NavLink's render prop for children */}
-                {({ isActive }) => (
-                  <>
-                    <span className={`material-symbols-outlined transition-colors group-hover:${isActive ? '' : 'text-primary'}`}>
-                      {item.icon}
-                    </span>
-                    <span className="text-sm font-medium">{item.name}</span>
-                  </>
-                )}
-              </NavLink>
-            ))}
-          </nav>
+          <div className="flex flex-col">
+            <h1 className="text-slate-900 dark:text-white text-base font-bold leading-tight">DistriCladera</h1>
+            <p className="text-slate-500 dark:text-slate-400 text-xs font-medium">Administración</p>
+          </div>
         </div>
 
-        <div className="px-2 py-3 border-t border-slate-100 dark:border-slate-800 mt-auto">
+        <nav className="flex flex-col gap-2">
+          {navItems.map((item) => (
+            <NavLink
+              key={item.name}
+              to={item.path}
+              onClick={handleNavClick}
+              className={({ isActive }) =>
+                `flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all group min-h-[44px] ${
+                  isActive
+                    ? 'bg-primary text-white shadow-md shadow-primary/20'
+                    : 'text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 active:bg-slate-200 dark:active:bg-slate-700 lg:hover:bg-slate-100 lg:dark:hover:bg-slate-800'
+                }`
+              }
+            >
+              {({ isActive }) => (
+                <>
+                  <span className={`material-symbols-outlined transition-colors group-hover:${isActive ? '' : 'text-primary'}`}>
+                    {item.icon}
+                  </span>
+                  <span className="text-sm font-medium">{item.name}</span>
+                </>
+              )}
+            </NavLink>
+          ))}
+        </nav>
+      </div>
+
+      <div className="flex flex-col gap-2 mt-auto">
+        {/* Sección inferior: modo oscuro, configuración, cerrar sesión */}
+        <div className="px-2 py-3 border-t border-slate-100 dark:border-slate-800 space-y-1">
+          <button
+            onClick={() => document.documentElement.classList.toggle('dark')}
+            className={`flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 active:bg-slate-200 dark:active:bg-slate-700 transition-colors ${touchTarget}`}
+            aria-label="Modo oscuro"
+          >
+            <span className="material-symbols-outlined">dark_mode</span>
+            <span className="text-sm font-medium">Modo oscuro</span>
+          </button>
+          <button
+            className={`flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 active:bg-slate-200 dark:active:bg-slate-700 transition-colors ${touchTarget}`}
+            aria-label="Configuración"
+          >
+            <span className="material-symbols-outlined">settings</span>
+            <span className="text-sm font-medium">Configuración</span>
+          </button>
+          {user && (
+            <button
+              onClick={handleLogout}
+              className={`flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 active:bg-slate-200 dark:active:bg-slate-700 transition-colors ${touchTarget}`}
+              aria-label="Cerrar sesión"
+            >
+              <span className="material-symbols-outlined">logout</span>
+              <span className="text-sm font-medium">Cerrar sesión</span>
+            </button>
+          )}
+        </div>
+
+        <div className="px-2 py-3 border-t border-slate-100 dark:border-slate-800">
           <div className="flex items-center gap-3">
-            <div 
-              className="size-9 rounded-full bg-cover bg-center border border-slate-200 dark:border-slate-700" 
-              style={{ 
-                backgroundImage: user?.avatar 
-                  ? `url("${user.avatar}")` 
+            <div
+              className="size-9 rounded-full bg-cover bg-center border border-slate-200 dark:border-slate-700 flex-shrink-0"
+              style={{
+                backgroundImage: user?.avatar
+                  ? `url("${user.avatar}")`
                   : 'url("https://lh3.googleusercontent.com/aida-public/AB6AXuBrprRuyoRqWKijO9YLnmZ8yNmz8EuDrlMAKCBMT3bJyak1YQo0vt5ayS-aQ70xZLidOtbwQbAhkTWd2gun7sC-m933JC2u56v97RZwieGtDH4qDDN30BBFVrsjHlRlM0lusRUhOl9F1LB3OmpkNAQypyvn6e7P1TVQKAbuWpA5E9GgOEy5xhrD1XT8s1vccaySv5vE864EyZ5VjH4a7q-SOKdq9BQnbcJZ2DNaHHl_Pcn3jD66pf5KNFnbQsI3sVZ83RwoU-hGIsaK")'
               }}
-            ></div>
-            <div className="flex flex-col overflow-hidden">
+            />
+            <div className="flex flex-col overflow-hidden min-w-0">
               <span className="text-sm font-semibold text-slate-900 dark:text-white truncate">
                 {user?.name || 'Usuario'}
               </span>
@@ -76,7 +136,37 @@ const Sidebar: React.FC = () => {
           </div>
         </div>
       </div>
-    </aside>
+    </div>
+  );
+
+  return (
+    <>
+      {/* Desktop: sidebar fijo visible desde lg (1024px) */}
+      <aside className="hidden lg:flex w-72 flex-col bg-white dark:bg-[#1a2634] border-r border-slate-200 dark:border-slate-800 h-full flex-shrink-0 z-20">
+        {sidebarContent}
+      </aside>
+
+      {/* Mobile: backdrop + drawer deslizable */}
+      <div className="lg:hidden">
+        <div
+          role="button"
+          tabIndex={-1}
+          aria-label="Cerrar menú"
+          className={`fixed inset-0 bg-black/50 z-30 transition-opacity duration-300 min-w-[44px] min-h-[44px] ${
+            isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
+          }`}
+          onClick={onClose}
+        />
+        <aside
+          className={`fixed inset-y-0 left-0 w-72 flex flex-col bg-white dark:bg-[#1a2634] border-r border-slate-200 dark:border-slate-800 z-40 transform transition-transform duration-300 ease-out shadow-xl ${
+            isOpen ? 'translate-x-0' : '-translate-x-full'
+          }`}
+          aria-hidden={!isOpen}
+        >
+          {sidebarContent}
+        </aside>
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Objetivo

Mejorar la experiencia en pantallas pequeñas (<1024px) manteniendo el comportamiento actual en desktop.

---

## Cambios realizados

### 1. Layout (`App.tsx`)

- Estado `sidebarOpen` para controlar el drawer en mobile.
- Paso de props `isOpen` / `onClose` al Sidebar y `onMenuToggle` / `sidebarOpen` al Header.

### 2. Header (`components/Header.tsx`)

- **Desktop (≥1024px):** Se mantiene el layout actual: título, búsqueda y los 4 botones (notificaciones, modo oscuro, configuración, cerrar sesión).
- **Mobile (<1024px):** Header simplificado:
  - Botón hamburguesa (izquierda) que abre/cierra el menú lateral.
  - Título centrado.
  - Botón de notificaciones (derecha).
  - Ocultos en el header: modo oscuro, configuración y cerrar sesión (se mueven al menú lateral).
- Área táctil mínima de 44px y `aria-label` en botones para accesibilidad.

### 3. Sidebar (`components/Sidebar.tsx`)

- **Desktop (≥1024px):** Sidebar fijo visible (breakpoint `lg`, 1024px). Nueva sección inferior con toggle modo oscuro, configuración y cerrar sesión (con confirmación).
- **Mobile (<1024px):** Sidebar como drawer deslizable desde la izquierda:
  - Backdrop oscuro; cierre al elegir una opción, tocar fuera o pulsar Escape.
  - Bloqueo de scroll del `body` cuando está abierto.
  - Transición de 300ms.

### 4. UX y accesibilidad

- Área táctil mínima 44px en botones.
- Estados `active:` en mobile y `hover:` en desktop.
- Cierre del drawer con Escape.
- Confirmación antes de cerrar sesión desde el sidebar.

---

## Breakpoint

- **1024px** (`lg` en Tailwind): límite entre vista mobile y desktop.

---

## Resultado

- **Desktop:** Sin cambios visuales respecto al estado anterior.
- **Mobile:** Header reducido, menú lateral como drawer y acciones secundarias dentro del menú.