### PR TITLE
Buscador de productos al agregar ítems en la creación de pedidos

### DIFF
--- a/components/NewOrderModal.tsx
+++ b/components/NewOrderModal.tsx
@@ -4,7 +4,7 @@ import { useClients } from '../contexts/ClientsContext';
 import { useProducts } from '../contexts/ProductsContext';
 import { useAuth } from '../hooks/useAuth';
 import { useAudit } from '../contexts/AuditContext';
-import { OrderStatus, OrderItem } from '../types';
+import { OrderStatus, OrderItem, Product } from '../types';
 
 interface NewOrderModalProps {
   isOpen: boolean;
@@ -22,6 +22,8 @@ const NewOrderModal: React.FC<NewOrderModalProps> = ({ isOpen, onClose }) => {
   const [orderDate, setOrderDate] = useState(new Date().toISOString().split('T')[0]);
   const [orderItems, setOrderItems] = useState<OrderItem[]>([]);
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
+  const [searchQueryByItem, setSearchQueryByItem] = useState<Record<number, string>>({});
+  const [openDropdownIndex, setOpenDropdownIndex] = useState<number | null>(null);
 
   useEffect(() => {
     if (!isOpen) {
@@ -31,8 +33,25 @@ const NewOrderModal: React.FC<NewOrderModalProps> = ({ isOpen, onClose }) => {
       setOrderDate(new Date().toISOString().split('T')[0]);
       setOrderItems([]);
       setErrors({});
+      setSearchQueryByItem({});
+      setOpenDropdownIndex(null);
     }
   }, [isOpen]);
+
+  const getFilteredProducts = (query: string): Product[] => {
+    const term = query.trim().toLowerCase();
+    if (!term) return products;
+    return products.filter(
+      (p) =>
+        p.id.toLowerCase().includes(term) ||
+        p.name.toLowerCase().includes(term) ||
+        p.brand.toLowerCase().includes(term) ||
+        p.category.toLowerCase().includes(term)
+    );
+  };
+
+  const getProductLabel = (p: Product) =>
+    `${p.name} (${p.brand}) - $${p.price.toFixed(2)} / ${p.unit}`;
 
   const handleAddProduct = () => {
     setOrderItems([...orderItems, { productId: '', estimatedQuantity: 1, price: 0, unit: 'Unidad' }]);
@@ -265,21 +284,76 @@ const NewOrderModal: React.FC<NewOrderModalProps> = ({ isOpen, onClose }) => {
                   const product = products.find(p => p.id === item.productId);
                   return (
                     <div key={index} className="flex gap-3 p-4 bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700">
-                      <div className="flex-1">
-                        <select
-                          value={item.productId}
-                          onChange={(e) => handleProductChange(index, 'productId', e.target.value)}
-                          className={`w-full px-3 py-2 bg-white dark:bg-slate-800 border rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary text-sm text-slate-900 dark:text-white ${
+                      <div className="flex-1 relative">
+                        <div
+                          className={`flex w-full items-center rounded-lg border bg-white dark:bg-slate-800 focus-within:ring-2 focus-within:ring-primary/20 focus-within:border-primary text-sm text-slate-900 dark:text-white ${
                             errors[`product_${index}`] ? 'border-red-500' : 'border-slate-200 dark:border-slate-700'
                           }`}
                         >
-                          <option value="">Seleccionar producto...</option>
-                          {products.map((product) => (
-                            <option key={product.id} value={product.id}>
-                              {product.name} ({product.brand}) - ${product.price.toFixed(2)} / {product.unit}
-                            </option>
-                          ))}
-                        </select>
+                          <span className="pl-3 text-slate-400 material-symbols-outlined text-[20px]">search</span>
+                          <input
+                            type="text"
+                            value={
+                              searchQueryByItem[index] !== undefined && searchQueryByItem[index] !== ''
+                                ? searchQueryByItem[index]
+                                : item.productId && product
+                                  ? getProductLabel(product)
+                                  : ''
+                            }
+                            onChange={(e) => {
+                              const value = e.target.value;
+                              if (value.trim() && item.productId) {
+                                handleProductChange(index, 'productId', '');
+                              }
+                              setSearchQueryByItem((prev) => ({ ...prev, [index]: value }));
+                            }}
+                            onFocus={() => setOpenDropdownIndex(index)}
+                            onBlur={() => setTimeout(() => setOpenDropdownIndex(null), 200)}
+                            placeholder="Buscar por ID, nombre, marca o categoría..."
+                            className="w-full min-w-0 py-2 pr-3 pl-1 bg-transparent border-none focus:ring-0 focus:outline-none text-sm"
+                          />
+                        </div>
+                        {openDropdownIndex === index && (
+                          <div className="absolute top-full left-0 right-0 mt-1 z-10 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg max-h-56 overflow-y-auto">
+                            {(() => {
+                              const query = searchQueryByItem[index] ?? '';
+                              const filtered = getFilteredProducts(query);
+                              if (filtered.length === 0) {
+                                return (
+                                  <div className="px-3 py-4 text-sm text-slate-500 dark:text-slate-400 text-center">
+                                    {query.trim()
+                                      ? 'Ningún producto coincide con la búsqueda'
+                                      : 'Escribí para buscar productos'}
+                                  </div>
+                                );
+                              }
+                              return (
+                                <ul className="py-1">
+                                  {filtered.map((p) => (
+                                    <li key={p.id}>
+                                      <button
+                                        type="button"
+                                        onClick={() => {
+                                          handleProductChange(index, 'productId', p.id);
+                                          setSearchQueryByItem((prev) => {
+                                            const next = { ...prev };
+                                            delete next[index];
+                                            return next;
+                                          });
+                                          setOpenDropdownIndex(null);
+                                          setErrors((prev) => ({ ...prev, [`product_${index}`]: '' }));
+                                        }}
+                                        className="w-full text-left px-3 py-2 text-sm hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+                                      >
+                                        {getProductLabel(p)}
+                                      </button>
+                                    </li>
+                                  ))}
+                                </ul>
+                              );
+                            })()}
+                          </div>
+                        )}
                         {errors[`product_${index}`] && (
                           <p className="text-xs text-red-500 mt-1">{errors[`product_${index}`]}</p>
                         )}


### PR DESCRIPTION
Permite a vendedores y administradores buscar productos por ID, descripción, marca o categoría al agregar ítems al pedido, en lugar de usar solo un desplegable con toda la lista del catálogo.

## Rama

- **Origen:** `feature/#9-Buscador-de-productos-al-agregar-ítems-en-la-creación-de-pedidos`
- **Destino:** `develop`

## Criterios de aceptación cumplidos

- [x] En la pantalla de creación de pedido, al agregar un producto, existe un campo de búsqueda visible en lugar del selector de producto.
- [x] La búsqueda filtra productos por ID, descripción/nombre, marca y categoría (un único texto que puede coincidir con cualquiera de estos campos).
- [x] Los resultados se actualizan al escribir (búsqueda en tiempo real).
- [x] Si no hay coincidencias, se muestra el mensaje: "Ningún producto coincide con la búsqueda".
- [x] Al elegir un producto de los resultados filtrados, se agrega correctamente al ítem del pedido y se rellenan precio y unidad como antes.
- [x] El comportamiento de cantidad, precio unitario y subtotal se mantiene sin cambios.

## Cambios realizados

### Comportamiento

- El `<select>` de producto se reemplazó por un **combobox** (input de búsqueda + lista desplegable).
- El filtrado se hace en el front sobre la lista de productos por: `id`, `name`, `brand` y `category` (coincidencia parcial, case-insensitive).
- Al hacer foco en el input se muestra la lista (todos los productos si no hay texto, o los filtrados).
- Al escribir, la lista se actualiza en tiempo real.
- Al seleccionar un producto de la lista se llama a la lógica existente (`handleProductChange`) y se rellenan precio, unidad y cantidad inicial; se cierra el dropdown y se limpia el término de búsqueda para esa fila.
- Si el usuario ya tenía un producto elegido y empieza a escribir de nuevo, se limpia la selección para esa fila hasta que elija otro producto.
- Al cerrar el modal se resetean el estado de búsqueda y el índice del dropdown abierto.

### Detalles de UX

- Ícono de búsqueda (Material Symbols `search`) a la izquierda del input.
- Placeholder: "Buscar por ID, nombre, marca o categoría...".
- Cuando no hay texto y el dropdown está abierto: mensaje "Escribí para buscar productos".
- Mismo estilo de borde y mensaje de error que el selector anterior (`errors[\`product_${index}\`]`).
- Cierre del dropdown con `onBlur` y `setTimeout(200 ms)` para que el clic en un ítem se registre correctamente.

### Implementación técnica

- **Estado nuevo:** `searchQueryByItem` (término de búsqueda por índice de ítem) y `openDropdownIndex` (índice de la fila con dropdown abierto).
- **Funciones:** `getFilteredProducts(query)` para filtrar productos; `getProductLabel(p)` para la etiqueta mostrada (nombre, marca, precio, unidad).
- **Validación:** sin cambios; se sigue exigiendo `productId` en submit.
- **Tipos:** se importa `Product` desde `types.ts` para el filtrado.

## Archivos modificados

| Archivo | Cambios |
|---------|--------|
| `components/NewOrderModal.tsx` | Import de `Product`; estado `searchQueryByItem` y `openDropdownIndex`; reset en `useEffect` al cerrar; `getFilteredProducts` y `getProductLabel`; reemplazo del `<select>` por input + dropdown con lista filtrada y mensajes de vacío/ningún resultado. |

## Cómo probar

1. Ir a la vista de pedidos y abrir "Crear Nuevo Pedido".
2. Agregar un producto y comprobar que aparece el campo de búsqueda con ícono y placeholder.
3. Escribir parte de un ID, nombre, marca o categoría y ver que la lista se filtra al instante.
4. Escribir un texto que no coincida con ningún producto y ver "Ningún producto coincide con la búsqueda".
5. Seleccionar un producto de la lista y ver que se rellenan precio, unidad y cantidad; verificar que cantidad, precio unitario y subtotal se comportan igual que antes.
6. Crear un pedido con uno o más ítems y confirmar que la validación y el envío funcionan igual.